### PR TITLE
target check: rework specs, refine messaging

### DIFF
--- a/lib/logstash/plugin_mixins/ecs_compatibility_support/target_check.rb
+++ b/lib/logstash/plugin_mixins/ecs_compatibility_support/target_check.rb
@@ -21,10 +21,24 @@ module LogStash
           base.prepend(RegisterDecorator)
         end
 
-        TARGET_NOT_SET_MESSAGE = ("ECS compatibility is enabled but `target` option was not specified. " +
-            "This may cause fields to be set at the top-level of the event where they are likely to clash with the Elastic Common Schema. " +
-            "It is recommended to set the `target` option to avoid potential schema conflicts (if your data is ECS compliant " +
-            "or non-conflicting, feel free to ignore this message)").freeze
+        ECS_TARGET_NOT_SET_MESSAGE = ("ECS compatibility is enabled but `target` option was not specified. " +
+          "This may cause fields to be set at the top-level of the event where they are likely to clash with the Elastic Common Schema. " +
+          "It is recommended to set the `target` option to avoid potential schema conflicts (if your data is ECS compliant " +
+          "or non-conflicting, feel free to ignore this message)").freeze
+
+        ECS_TARGET_NOT_SET_PREFER_CODEC_MESSAGE = ("ECS compatibility is enabled but `target` option was not specified for this plugin or its codec." +
+          "This may cause fields to be set at the top-level of the event where they are likely to clash with the Elastic Common Schema. " +
+          "When a plugin and its codec both provide a `target` option, it is recommended to set the `target` option on the codec to avoid potential schema conflicts " +
+          "(if your data is ECS compliant or non-conflicting, feel free to ignore this message)."
+        ).freeze
+
+        MULTIPLE_TARGETS_SET_MESSAGE = ("This plugin and its codec are both configured with a `target` option, which can lead to surprising results. " +
+          "In general, it is recommended to only set the codec's `target`.").freeze
+
+        PREFER_CODEC_TARGET_MESSAGE_TEMPLATE = ("Both this plugin and its codec provide a `target` option, but the codec's `target` was left unspecified. "+
+          "In general, it is recommended to only set the codec's `target`. "+
+          "To do so, remove the `target` directive from this plugin and instead define the codec with " +
+          "`codec => %s { target => %p }`").freeze
 
         private
 
@@ -39,6 +53,17 @@ module LogStash
           false # target isn't set
         end
 
+        ##
+        # Check whether a codec is present and specifies a target.
+        #
+        # @return [nil] if codec not present or codec does not support target
+        # @return [true,false]
+        def codec_target_set?
+          return nil unless respond_to?(:codec)
+          return nil unless codec.respond_to?(:target)
+          !codec.target.nil?
+        end
+
         module RegisterDecorator
 
           ##
@@ -46,7 +71,27 @@ module LogStash
           # @override
           def register
             super.tap do
-              logger.info(TARGET_NOT_SET_MESSAGE) if target_set? == false
+              plugin_targeted = target_set?
+              codec_targeted = codec_target_set?
+
+              if plugin_targeted
+                if codec_targeted
+                  # both is not good. prefer codec.
+                  logger.warn(MULTIPLE_TARGETS_SET_MESSAGE)
+                elsif codec_targeted == false
+                  # prefer codec's target option
+                  logger.info(PREFER_CODEC_TARGET_MESSAGE_TEMPLATE % [codec.config_name, target])
+                end
+              elsif (plugin_targeted == false)
+                # ECS enabled and plugin not targeted
+                if codec_targeted.nil?
+                  # codec does not support target
+                  logger.info(ECS_TARGET_NOT_SET_MESSAGE)
+                elsif codec_targeted == false
+                  # codec supports target, but it is unspecified
+                  logger.info(ECS_TARGET_NOT_SET_PREFER_CODEC_MESSAGE)
+                end
+              end
             end
           end
 

--- a/logstash-mixin-ecs_compatibility_support.gemspec
+++ b/logstash-mixin-ecs_compatibility_support.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-mixin-ecs_compatibility_support'
-  s.version       = '1.3.0'
+  s.version       = '1.3.1'
   s.licenses      = %w(Apache-2.0)
   s.summary       = "Support for the ECS-Compatibility mode introduced in Logstash 7.x, for plugins wishing to use this API on older Logstashes"
   s.description   = "This gem is meant to be a dependency of any Logstash plugin that wishes to use the ECS-Compatibility mode introduced in Logstash 7.x while maintaining backward-compatibility with earlier Logstash releases. When used on older Logstash versions, this adapter provides an implementation of ECS-Compatibility mode that can be controlled at the plugin instance level."

--- a/spec/logstash/plugin_mixins/ecs_compatibility_support/target_check_spec.rb
+++ b/spec/logstash/plugin_mixins/ecs_compatibility_support/target_check_spec.rb
@@ -10,12 +10,45 @@ require 'logstash/outputs/base'
 require "logstash/plugin_mixins/ecs_compatibility_support/target_check"
 
 describe LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck do
+  subject(:plugin) { plugin_class.new(plugin_params) }
+  let(:plugin_params) { Hash.new }
 
-  describe "check_target_set_in_ecs_mode" do
+  let(:logger) { double("Logger").as_null_object }
+  before { allow(plugin).to receive(:logger).and_return(logger)}
 
-    context 'with a plugin' do
+  context 'with a plugin' do
 
-      subject(:plugin_class) do
+    shared_examples "check target set" do
+      context("ECS disabled") do
+        let(:plugin_params) { super().merge('ecs_compatibility' => 'disabled') }
+        it 'does not log info about setting the target' do
+          expect(plugin.register).to eql 42
+          expect(plugin.logger).to_not have_received(:info).with(a_string_including "`target` option")
+        end
+      end
+
+      context "ECS enabled" do
+        let(:plugin_params) { super().merge('ecs_compatibility' => 'v1') }
+
+        context "when target not set" do
+          it 'emits a helpful info log' do
+            expect(plugin.register).to eql 42
+            expect( plugin.logger ).to have_received(:info).with(a_string_including "ECS compatibility is enabled but `target` option was not specified.")
+          end
+        end
+
+        context "when target is provided" do
+          let(:plugin_params) { super().merge('target' => 'foo') }
+          it 'does not emit an info log about setting the target' do
+            expect(plugin.register).to eql 42
+            expect(plugin.logger).to_not have_received(:info).with(a_string_including "`target` option")
+          end
+        end
+      end
+    end
+
+    context "filter" do
+      let(:plugin_class) do
         Class.new(LogStash::Filters::Base) do
           include LogStash::PluginMixins::ECSCompatibilitySupport
           include LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck
@@ -23,45 +56,107 @@ describe LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck do
           config :target, :validate => :string
 
           def register; 42 end
-
         end
       end
 
-      it 'skips check when ECS disabled' do
-        plugin = plugin_class.new('ecs_compatibility' => 'disabled')
-        allow( plugin.logger ).to receive(:info)
-        expect( plugin.register ).to eql 42
-        expect( plugin.logger ).to_not have_received(:info).with(a_string_including "`target` option")
-      end
-
-      it 'warns when target is not set in ECS mode' do
-        plugin = plugin_class.new('ecs_compatibility' => 'v1')
-        allow( plugin.logger ).to receive(:info)
-        expect( plugin.register ).to eql 42
-        expect( plugin.logger ).to have_received(:info).with(a_string_including "ECS compatibility is enabled but `target` option was not specified.")
-      end
-
-      it 'does not warn when target is set' do
-        plugin = plugin_class.new('ecs_compatibility' => 'v1', 'target' => 'foo')
-        allow( plugin.logger ).to receive(:info)
-        expect( plugin.register ).to eql 42
-        expect( plugin.logger ).to_not have_received(:info).with(a_string_including "`target` option")
-      end
-
+      include_examples("check target set")
     end
 
-    it 'fails check when no target config' do
-      plugin_class = Class.new(LogStash::Filters::Base) do
+    context "input" do
+      let(:plugin_class) do
+        Class.new(LogStash::Inputs::Base) do
+          include LogStash::PluginMixins::ECSCompatibilitySupport
+          include LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck
+
+          config :target, :validate => :string
+
+          def register; 42 end
+        end
+      end
+      let(:codec) { codec_class.new(codec_params) }
+      let(:codec_params) { Hash.new }
+
+      context 'when configured with a codec that does not support `target`' do
+        let(:codec_class) do
+          Class.new(LogStash::Codecs::Base)
+        end
+        let(:plugin_params) { super().merge('codec' => codec) }
+
+        include_examples("check target set")
+      end
+
+      context 'when configured with a codec that supports `target`' do
+        let(:codec_class) do
+          Class.new(LogStash::Codecs::Base) do
+            config_name :dummy
+            config :target, :validate => :string
+          end
+        end
+        let(:plugin_params) { super().merge('codec' => codec) }
+
+
+        context "and neither the input's target nor the codec's target is set" do
+          context "and ECS compatibility is enabled" do
+            let(:plugin_params) { super().merge('ecs_compatibility' => 'v1') }
+            it "logs info advocating for setting the codec's target" do
+              expect(plugin.register).to eq(42)
+              expect(plugin.logger).to have_received(:info).with(a_string_including "set the `target` option on the codec")
+            end
+          end
+          context "and ECS compatibility is disabled" do
+            let(:plugin_params) { super().merge('ecs_compatibility' => 'disabled') }
+            it "does not log info about targets" do
+              expect(plugin.register).to eq(42)
+              expect(plugin.logger).to_not have_received(:info).with(a_string_including "`target`")
+            end
+          end
+        end
+
+        context "and both the input's target and the codec's target are specified" do
+          let(:plugin_params) { super().merge('target' => 'outer') }
+          let(:codec_params) { super().merge('target' => 'inner') }
+
+          it 'logs a warning about target being specified multiple places' do
+            expect(plugin.register).to eq(42)
+            expect(plugin.logger).to have_received(:warn).with(a_string_including "This plugin and its codec are both configured with a `target` option")
+          end
+        end
+
+        context "and target is provided in the input but not the codec" do
+          let(:plugin_params) { super().merge('target' => 'outer') }
+
+          it "logs info about preferring the codec's target" do
+            expect(plugin.register).to eq(42)
+            expect(plugin.logger).to have_received(:info).with(a_string_including("codec's `target` was left unspecified")
+                                                               .and(including "only set the codec's `target`")
+                                                               .and(including "`codec => dummy { target => \"outer\" }`"))
+          end
+        end
+
+        context "and target is provided in the codec but not the input" do
+          let(:codec_params) { super().merge('target' => 'inner') }
+
+          it "does not log info about target" do
+            expect(plugin.register).to eq(42)
+            expect(plugin.logger).to_not have_received(:info).with(a_string_including("`target`"))
+          end
+        end
+      end
+    end
+  end
+
+  context 'with a plugin that does not have target config' do
+    let(:plugin_class) do
+      Class.new(LogStash::Filters::Base) do
         include LogStash::PluginMixins::ECSCompatibilitySupport
         include LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck
 
         def register; end
-
       end
-      plugin = plugin_class.new('ecs_compatibility' => 'v1')
+    end
+    it 'raises an error at registration' do
       expect { plugin.register }.to raise_error NameError, /\btarget\b/
     end
-
   end
 
 end


### PR DESCRIPTION
Re-works the specs to add layers of conditions, which ensures we capture all of the edge-cases we are looking to specify.

In doing so, I discovered that the messaging I suggested earlier in some cases was less helpful than it could be 🤦🏼‍♂️  so I introduced a new message for when (a) ECS is enabled and (b) the target is unspecified and (c) the codec supports a target but it isn't specified there either. This message encourages them to jump straight to configuring the codec. In theory, they will get a companion log message from the codec (if it uses this library), but I figured both together will be helpful. 

I also memoised the calls to `target_set?` and `codec_target_set?` to local variables so we can avoid calling them repeatedly.

~~~
logstash_1  | LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck
logstash_1  |   with a plugin
logstash_1  |     filter
logstash_1  |       ECS disabled
logstash_1  |         does not log info about setting the target
logstash_1  |       ECS enabled
logstash_1  |         when target not set
logstash_1  |           emits a helpful info log
logstash_1  |         when target is provided
logstash_1  |           does not emit an info log about setting the target
logstash_1  |     input
logstash_1  |       when configured with a codec that does not support `target`
logstash_1  |         ECS disabled
logstash_1  |           does not log info about setting the target
logstash_1  |         ECS enabled
logstash_1  |           when target not set
logstash_1  |             emits a helpful info log
logstash_1  |           when target is provided
logstash_1  |             does not emit an info log about setting the target
logstash_1  |       when configured with a codec that supports `target`
logstash_1  |         and neither the input's target nor the codec's target is set
logstash_1  |           and ECS compatibility is enabled
logstash_1  |             logs info advocating for setting the codec's target
logstash_1  |           and ECS compatibility is disabled
logstash_1  |             does not log info about targets
logstash_1  |         and both the input's target and the codec's target are specified
logstash_1  |           logs a warning about target being specified multiple places
logstash_1  |         and target is provided in the input but not the codec
logstash_1  |           logs info about preferring the codec's target
logstash_1  |         and target is provided in the codec but not the input
logstash_1  |           does not log info about target
logstash_1  |   with a plugin that does not have target config
logstash_1  |     raises an error at registration
~~~